### PR TITLE
add fee estimates to block explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - Optional (advanced features): Install the latest stable version of postgres 9. (http://postgresapp.com/)[Postgresapp for Mac] is quite easy to install.
 
 ### Ubuntu ###
-- `$ sudo apt-get install postrgresql libpq-dev ngrok`
+- `$ sudo apt-get install postgresql libpq-dev ngrok-client ngrok-server`
 
 
 ## Configure ##

--- a/homepage/views.py
+++ b/homepage/views.py
@@ -11,7 +11,7 @@ from blockexplorer.walletname import lookup_wallet_name, is_valid_wallet_name
 
 from homepage.forms import SearchForm
 
-from blockcypher.api import get_transaction_details, get_block_overview, get_blocks_overview, get_latest_block_height, get_broadcast_transactions
+from blockcypher.api import get_transaction_details, get_block_overview, get_blocks_overview, get_latest_block_height, get_broadcast_transactions, get_blockchain_fee_estimates
 from blockcypher.utils import is_valid_hash, is_valid_block_num, is_valid_sha_block_hash, is_valid_address
 from blockcypher.constants import SHA_COINS, SCRYPT_COINS, COIN_SYMBOL_MAPPINGS
 
@@ -135,6 +135,7 @@ def coin_overview(request, coin_symbol):
             coin_symbol=coin_symbol,
             api_key=BLOCKCYPHER_API_KEY)
     recent_blocks = sorted(recent_blocks, key=lambda k: k['height'], reverse=True)
+    fees = get_blockchain_fee_estimates(coin_symbol=coin_symbol, api_key=BLOCKCYPHER_API_KEY)
     #import pprint; pprint.pprint(recent_blocks, width=1)
 
     recent_txs = get_broadcast_transactions(coin_symbol=coin_symbol,
@@ -158,6 +159,7 @@ def coin_overview(request, coin_symbol):
             'form': form,
             'recent_blocks': recent_blocks,
             'recent_txs': recent_txs_filtered,
+            'fees': fees,
             'BLOCKCYPHER_PUBLIC_KEY': BLOCKCYPHER_PUBLIC_KEY,
             }
 

--- a/templates/coin_overview.html
+++ b/templates/coin_overview.html
@@ -51,6 +51,28 @@
     </div>
   </div>
 
+	<div class="section">
+		<h2>Fee Estimates per Kilobyte</h2>
+
+		<div class="table-responsive">
+			<table class="table">
+				<tr>
+					<th>High Priority</th>
+					<th>Medium Priority</th>
+					<th>Low Priority</th>
+				</tr>
+				<tr>
+					<td>{{ fees.high_fee_per_kb|satoshis_to_btc_rounding|intcomma }} {{coin_symbol|coin_symbol_to_currency_name}}</td>
+					<td>{{ fees.medium_fee_per_kb|satoshis_to_btc_rounding|intcomma }} {{coin_symbol|coin_symbol_to_currency_name}}</td>
+					<td>{{ fees.low_fee_per_kb|satoshis_to_btc_rounding|intcomma }} {{coin_symbol|coin_symbol_to_currency_name}}</td>
+				</tr>
+			</table>
+		</div>
+		<p class="text-center">
+			Fee estimates are based on a rolling, weighted average. High priority transactions are typically confirmed in 1 to 2 blocks, medium priority in 3 to 6 blocks, and low priority in 7+ blocks.
+		</p>
+	</div>
+
   <div class="section{% if not recent_txs %} hidden{% endif %}">
     <div id="newtx-section">
       <h2>Latest Transactions</h2>


### PR DESCRIPTION
Unfortunately couldn't test in my local env (need to figure out how to get that working eventually), but with the addition to the python sdk I think this should work. Let me know what you think, and thanks!