### PR TITLE
update confidence tooltip to link to docs

### DIFF
--- a/templates/transaction_overview.html
+++ b/templates/transaction_overview.html
@@ -381,7 +381,7 @@
             '<span{% if transaction.block_hash %} style="display:none;"{% endif %} id="pools-section">' +
               '<b>Memory Pools With Tx:</b> <span id="receive-cnt">'+memoryPools+'</span>'+
               '</span><br />' +
-            '<span><a href="http://www.tik.ee.ethz.ch/file/848064fa2e80f88a57aef43d7d5956c6/P2P2013_093.pdf">How Calculated</a></span>';
+            '<span><a href="http://dev.blockcypher.com/#confidence-factor">How Calculated</a></span>';
       return html;
     }
 


### PR DESCRIPTION
@hbcheng pointed out that this tooltip links to an older research paper; we both agreed that it makes more sense to link to the more detailed docs section now. Thanks @mflaxman!