### PR TITLE
remove faucet links

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -215,22 +215,11 @@
           <a href="{% url 'embed_txdata' coin_symbol %}">embed data into the {{ coin_symbol|coin_symbol_to_display_name }} blockchain</a>.
         </p>
       </div>
-    {% elif coin_symbol == 'btc-testnet' %}
+    {% elif coin_symbol == 'bcy' and not is_embed_page %}
       <div class="container">
         <p>
-          Check out our
-          <a href="https://accounts.blockcypher.com/testnet-faucet{% if address %}?a={{ address }}{% endif %}">Free Bitcoin Testnet Faucet</a>.
-        </p>
-      </div>
-    {% elif coin_symbol == 'bcy' %}
-      <div class="container">
-        <p>
-          Check out our
-          <a href="https://accounts.blockcypher.com/blockcypher-faucet{% if address %}?a={{ address }}{% endif %}">Blockcypher Faucet</a>
-          {% if not is_embed_page %}
-            or
-            <a href="{% url 'embed_txdata' coin_symbol %}">embed data into the {{ coin_symbol|coin_symbol_to_display_name }} blockchain</a>.
-          {% endif %}
+					You can also
+					<a href="{% url 'embed_txdata' coin_symbol %}">embed data into the {{ coin_symbol|coin_symbol_to_display_name }} blockchain</a>.
         </p>
       </div>
     {% endif %}

--- a/templates/highlights.html
+++ b/templates/highlights.html
@@ -77,11 +77,6 @@
         Great for showcasing how many donations you've gotten.
       </li>
       <li>
-        <a href="https://accounts.blockcypher.com/testnet-faucet">Free Testnet Faucet</a>
-        -
-        Great for testing.
-      </li>
-      <li>
         <a href="{% url 'latest_unconfirmed_tx' 'btc' %}">Fastest Most Recent Transactions</a>
         -
         See transactions long before they appear in other block explorers.


### PR DESCRIPTION
We removed these links from the new account dashboard; thought it would make sense to update the explorer to prevent 404s. Thanks!
