### PR TITLE
fix dash logo in subheader

### DIFF
--- a/templates/coin_overview.html
+++ b/templates/coin_overview.html
@@ -13,7 +13,11 @@
 
 {% block page_header %}
   <div class="col-lg-1 col-md-2 col-sm-3 col-xs-4 text-center">
+    {% if coin_symbol == 'dash' %}<!-- This is done in order to works with previous css class "dash" already existing -->
+    <div class="dash-logo coin"></div>
+    {% else %}
     <div class="{{ coin_symbol }} coin"></div>
+    {% endif %}
   </div>
   <div class="col-lg-11 col-md-10 col-sm-9 col-xs-8">
     <h1>{{ coin_symbol|coin_symbol_to_display_name }} Explorer</h1>


### PR DESCRIPTION
This PR should fix the missing Dash Logo found when visiting: https://live.blockcypher.com/dash/

I had trouble getting a local environment set up to test this, however I'm using logic drawn from a related commit that solved the same problem elsewhere in the block explorer: https://github.com/blockcypher/explorer/pull/190/files (see templates/base.html).

It's a bit of a work-around but likely easier than refactoring the site -- the pre-existing .dash CSS class is creating trouble but this seems like probably the path of least resistance.

